### PR TITLE
Add demosite to theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -4,6 +4,7 @@ license = "MIT"
 licenselink = "https://github.com/gesquive/slate/blob/master/LICENSE.md"
 description = "A speed dial theme"
 homepage = "http://github.com/gesquive/slate"
+demosite="https://gesquive.github.io/hugo-slate-demo/"
 tags = ["speed-dial", "single-page"]
 features = []
 min_version = "0.20"


### PR DESCRIPTION
Hey,

I have revamped the scripts that builds Hugo's theme site. For now at least, we're not building demo sites.

I'm adding this PR mostly to test the process. 

Could you merge this and then create a new release tag?